### PR TITLE
Update support for stack to ghc8.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,23 @@ examples : stdlib
 	cabal v2-run -O2 jhc -- -L . examples/Calendar.hs -o calendar
 	cabal v2-run -O2 jhc -- -L . examples/HelloWorld.hs -o hello
 	cabal v2-run -O2 jhc -- -L . examples/Primes.hs -o primes
+
+.PHONEY: jhc-stack
+jhc-stack:
+	stack build
+
+.PHONEY: stdlib-stack
+stdlib-stack : jhc-stack
+	stack exec jhc -- -L . --build-hl  lib/jhc-prim/jhc-prim.yaml
+	stack exec jhc -- -L . --build-hl  lib/jhc/jhc.yaml
+	stack exec jhc -- -L . --build-hl  lib/haskell-extras/haskell-extras.yaml
+	stack exec jhc -- -L . --build-hl  lib/haskell2010/haskell2010.yaml
+	stack exec jhc -- -L . --build-hl  lib/haskell98/haskell98.yaml
+	stack exec jhc -- -L . --build-hl  lib/applicative/applicative.yaml
+	stack exec jhc -- -L . --build-hl  lib/flat-foreign/flat-foreign.yaml
+
+.PHONEY: examples-stack
+examples-stack : stdlib-stack
+	stack exec jhc -- -L . examples/Calendar.hs -o calendar
+	stack exec jhc -- -L . examples/HelloWorld.hs -o hello
+	stack exec jhc -- -L . examples/Primes.hs -o primes

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-2.22
+resolver: nightly-2020-08-16
 
 packages:
   - jhc-compat


### PR DESCRIPTION
Usage instructions:
To use stack for building, first you need to install stack.

Instructions can be found here: https://docs.haskellstack.org/en/stable/README/

Once you have `stack` as a command in your shell, you can run

```
stack build
```

from the root folder of `jhc-components` and stack will install the
correct ghc version, find all the required packages in a single set that
has no conflicts, download and build them. Lastly stack builds
jhc-components and its packages.

To run jhc, the syntax is:
```
stack exec jhc -- my jhc args
```

The key reason this works is that in the `stack.yaml` file, there is a
reference to: `resolver: nightly-2020-08-16`. This means that stack will
query stackage.org for a non-conflicting package set that it compiled
that night. This package set is the last one compiled with ghc-8.10.

In other words, we are outsourcing the work of finding a non-conflicting
set of packages to stackage, which has a much more elaborate way of
checking this, by actually building all the packages together, than
cabal, which just relies on version and dependency information.